### PR TITLE
[tvOS] Raised the `MinimumOSVersion` as a temporary fix of submission

### DIFF
--- a/UICatalog_DontLink/UICatalog/Info.plist
+++ b/UICatalog_DontLink/UICatalog/Info.plist
@@ -26,7 +26,7 @@
 	<key>GCSupportsControllerUserInteraction</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>10.0</string>
+	<string>11.3</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>


### PR DESCRIPTION
Submission fails if Target Version is 10.0. It's a platform [issue](https://github.com/xamarin/xamarin-macios/issues/4257). 
It's a temporary fix while the team doesn't fix it.