### PR TITLE
[iTravelApp]Add missing key needed to complete the submission.

### DIFF
--- a/iTravel/iTravel/Info.plist
+++ b/iTravel/iTravel/Info.plist
@@ -48,5 +48,7 @@
 	<string>Location (always)</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Location (in use)</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>We need your bluetooh device to give better service.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes issue with the submission of the app:

> ITMS-90683: Missing Purpose String in Info.plist - Your app's code references one or more APIs that access sensitive user data. The app's Info.plist file should contain a NSBluetoothAlwaysUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. Starting Spring 2019, all apps submitted to the App Store that access user data are required to include a purpose string. If you're using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. You can contact the developer of the library or SDK and request they release a version of their code that doesn't contain the APIs.