### PR TITLE
[.NET] Use SupportedOSPlatformVersion in the project files instead of the min OS version in the Info.plist.

### DIFF
--- a/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
+++ b/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharpiOSCoolApp</RootNamespace>
     <AssemblyName>FSharpiOSCoolApp</AssemblyName>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>
     <BuildIpa>true</BuildIpa>
     <GenerateTailCalls>true</GenerateTailCalls>

--- a/FSharpiOSCoolApp/dotnet/Info.plist
+++ b/FSharpiOSCoolApp/dotnet/Info.plist
@@ -12,8 +12,6 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/MacCoolApp_DontLink/dotnet/Info.plist
+++ b/MacCoolApp_DontLink/dotnet/Info.plist
@@ -24,8 +24,6 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.15</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>olegoid</string>
 	<key>NSMainNibFile</key>

--- a/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
+++ b/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
@@ -10,6 +10,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MacCoolApp</RootNamespace>
     <AssemblyName>MacCoolApp</AssemblyName>
+    <SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
 
     <CreatePackage>true</CreatePackage>
     <EnableCodeSigning>true</EnableCodeSigning>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOS/Info.plist
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOS/Info.plist
@@ -8,8 +8,6 @@
 	<string>ODRsTVOS</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.xamarin.odr-tvos.dotnet</string>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ODRsTVOS</RootNamespace>
     <AssemblyName>ODRsTVOS</AssemblyName>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
 
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/Info.plist
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/Info.plist
@@ -14,8 +14,6 @@
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
-	<key>MinimumOSVersion</key>
-	<string>10.2</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/ODRsTVOSExt.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/ODRsTVOSExt.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>ODRsTVOSExt</RootNamespace>
     <AssemblyName>ODRsTVOSExt</AssemblyName>
     <IsAppExtension>true</IsAppExtension>
+    <SupportedOSPlatformVersion>10.2</SupportedOSPlatformVersion>
 
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>

--- a/SceneKitGame/dotnet/Info.plist
+++ b/SceneKitGame/dotnet/Info.plist
@@ -8,8 +8,6 @@
 	<string>SceneKitGame</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.xamarin.scenekit-tvos.dotnet</string>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>

--- a/SceneKitGame/dotnet/SceneKitGame.csproj
+++ b/SceneKitGame/dotnet/SceneKitGame.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>SceneKitGame</RootNamespace>
     <AssemblyName>SceneKitGame</AssemblyName>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
 
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>

--- a/UICatalog/dotnet/Info.plist
+++ b/UICatalog/dotnet/Info.plist
@@ -21,8 +21,6 @@
 	</array>
 	<key>GCSupportsControllerUserInteraction</key>
 	<true/>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>

--- a/UICatalog/dotnet/UICatalog.csproj
+++ b/UICatalog/dotnet/UICatalog.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>UICatalog</RootNamespace>
     <AssemblyName>UICatalog</AssemblyName>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
 
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>

--- a/iOSCoolApp/dotnet/Info.plist
+++ b/iOSCoolApp/dotnet/Info.plist
@@ -14,8 +14,6 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/iOSCoolApp/dotnet/iOSCoolApp.csproj
+++ b/iOSCoolApp/dotnet/iOSCoolApp.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>iOSCoolApp</RootNamespace>
     <AssemblyName>iOSCoolApp</AssemblyName>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>
     <CodesignProvision>iOS Publish Workflow II - Distribution Profile (.N</CodesignProvision>
     <BuildIpa>true</BuildIpa>

--- a/iTravel/dotnet/Info.plist
+++ b/iTravel/dotnet/Info.plist
@@ -10,8 +10,6 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/iTravel/dotnet/iTravel.csproj
+++ b/iTravel/dotnet/iTravel.csproj
@@ -11,6 +11,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>iTravel</RootNamespace>
     <AssemblyName>iTravel</AssemblyName>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>
     <OnDemandResourcesPrefetchOrder>paris</OnDemandResourcesPrefetchOrder>
     <OnDemandResourcesInitialInstallTags>rotterdam</OnDemandResourcesInitialInstallTags>


### PR DESCRIPTION
This is a consequence of recent changes in our .NET support.