### PR TITLE
Add AppIntentVocabulary file to intents sample

### DIFF
--- a/WatchOSIntents/intentsphone/AppIntentVocabulary.plist
+++ b/WatchOSIntents/intentsphone/AppIntentVocabulary.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IntentPhrases</key>
+	<array>
+		<dict>
+			<key>IntentName</key>
+			<string>INGetRideStatusIntent</string>
+			<key>IntentExamples</key>
+			<array>
+				<string>Get ride status</string>
+			</array>
+		</dict>
+		<dict>
+			<key>IntentName</key>
+			<string>INListRideOptionsIntent</string>
+			<key>IntentExamples</key>
+			<array>
+				<string>List rides</string>
+			</array>
+		</dict>
+		<dict>
+			<key>IntentName</key>
+			<string>INRequestRideIntent</string>
+			<key>IntentExamples</key>
+			<array>
+				<string>Start a ride</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
We were getting:

```
We identified one or more issues with a recent delivery for your app, "Intents Sample" 1.84821412 (1.84821412). Your delivery was successful, but you may wish to correct the following issues in your next delivery: 

ITMS-90626: Invalid Siri Support - No example phrase was provided for INRequestRideIntent in the 'en' language. Please refer to 'https://developer.apple.com/documentation/sirikit/registering_custom_vocabulary_with_sirikit/global_vocabulary_reference/intent_phrases'

ITMS-90626: Invalid Siri Support - No example phrase was provided for INListRideOptionsIntent in the 'en' language. Please refer to 'https://developer.apple.com/documentation/sirikit/registering_custom_vocabulary_with_sirikit/global_vocabulary_reference/intent_phrases'

ITMS-90626: Invalid Siri Support - No example phrase was provided for INGetRideStatusIntent in the 'en' language. Please refer to 'https://developer.apple.com/documentation/sirikit/registering_custom_vocabulary_with_sirikit/global_vocabulary_reference/intent_phrases' 
```