### PR TITLE
Fix icons for dotnet ports of submission tests

### DIFF
--- a/FSharpiOSCoolApp/dotnet/Info.plist
+++ b/FSharpiOSCoolApp/dotnet/Info.plist
@@ -41,6 +41,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>XSAppIconAssets</key>
-	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<string>../FSharpiOSCoolApp/Resources/Images.xcassets/AppIcons.appiconset</string>
 </dict>
 </plist>

--- a/SceneKitGame/dotnet/Info.plist
+++ b/SceneKitGame/dotnet/Info.plist
@@ -32,9 +32,9 @@
 	<key>GCSupportsControllerUserInteraction</key>
 	<true/>
 	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/App Icon &amp; Top Shelf Image.brandassets</string>
+	<string>../SceneKitGame/Assets.xcassets/App Icon &amp; Top Shelf Image.brandassets</string>
 	<key>XSLaunchImageAssets</key>
-	<string>Assets.xcassets/LaunchImages.launchimage</string>
+	<string>../SceneKitGame/Assets.xcassets/LaunchImages.launchimage</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/UICatalog/dotnet/Info.plist
+++ b/UICatalog/dotnet/Info.plist
@@ -36,7 +36,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>XSAppIconAssets</key>
-	<string>Resources/Images.xcassets/Brand Assets.brandassets</string>
+	<string>../UICatalog/Resources/Images.xcassets/Brand Assets.brandassets</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/iOSCoolApp/dotnet/Info.plist
+++ b/iOSCoolApp/dotnet/Info.plist
@@ -43,6 +43,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>XSAppIconAssets</key>
-	<string>Resources/Images.xcassets/AppIcons.appiconset</string>
+	<string>../iOSCoolApp/Resources/Images.xcassets/AppIcons.appiconset</string>
 </dict>
 </plist>

--- a/iTravel/dotnet/Info.plist
+++ b/iTravel/dotnet/Info.plist
@@ -29,7 +29,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/AppIcons.appiconset</string>
+	<string>../iTravel/Assets.xcassets/AppIcons.appiconset</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>NSCalendarsUsageDescription</key>


### PR DESCRIPTION
- Part of https://github.com/xamarin/xamarin-macios/issues/12279
- Turns out paths in Info.plist are relative to the directory we're beside (BundleResource.GetVirtualProjectPath) and we were not resolving any icons in net6 tests