### PR TITLE
Setup MacCoolApp (NET6) to be duel x86_64/arm64 as required by submission tests now

### DIFF
--- a/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
+++ b/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
@@ -6,7 +6,7 @@
         // actually because of QTKit deprecation we are forced to use "Link SDK" and an XML file that preserve (almost) everything else
     -->
     <TargetFramework>net6.0-macos</TargetFramework>
-    <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
+    <RuntimeIdentifiers>osx-arm64;osx-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>MacCoolApp</RootNamespace>
     <AssemblyName>MacCoolApp</AssemblyName>


### PR DESCRIPTION
Submission Test Failure:

```
*** Error: Validation failed for '../../../../SubmissionSamples/MacCoolApp_DontLink/dotnet/bin/Release/net6.0-macos/osx-arm64/MacCoolApp-1.93472126.pkg'.
*** Error: Invalid Bundle. The bundle 'MacCoolApp.app' supports arm64 but not Intel. Your build must include the x86_64 architecture to support Intel. For more about supporting Intel-based Mac computers, see: https://developer.apple.com/documentation/xcode/building_a_universal_macos_binary App Store operation failed. (1091)
 {
    NSLocalizedDescription = "Invalid Bundle. The bundle 'MacCoolApp.app' supports arm64 but not Intel. Your build must include the x86_64 architecture to support Intel. For more about supporting Intel-based Mac computers, see: https://developer.apple.com/documentation/xcode/building_a_universal_macos_binary";
    NSLocalizedFailureReason = "App Store operation failed.";
    NSLocalizedRecoverySuggestion = "Invalid Bundle. The bundle 'MacCoolApp.app' supports arm64 but not Intel. Your build must include the x86_64 architecture to support Intel. For more about supporting Intel-based Mac computers, see: https://developer.apple.com/documentation/xcode/building_a_universal_macos_binary";
}
```

This just seems to work:

```
donblas:~/Programming/SubmissionSamples/MacCoolApp_DontLink/dotnet/bin/Release/net6.0-macos $ file ./MacCoolApp.app/Contents/MacOS/MacCoolApp 
./MacCoolApp.app/Contents/MacOS/MacCoolApp: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
./MacCoolApp.app/Contents/MacOS/MacCoolApp (for architecture x86_64):	Mach-O 64-bit executable x86_64
./MacCoolApp.app/Contents/MacOS/MacCoolApp (for architecture arm64):	Mach-O 64-bit executable arm64
```