### PR TITLE
Mark ODRsTVOS' extension project as such.

### DIFF
--- a/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
@@ -108,7 +108,9 @@
     </BundleResource>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ODRsTVOSExt\ODRsTVOSExt.csproj" />
+    <ProjectReference Include="..\ODRsTVOSExt\ODRsTVOSExt.csproj">
+      <IsAppExtension>true</IsAppExtension>
+    </ProjectReference>
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION
This makes us actually treat the extension as an extension, and embed it in
the app bundle.