### PR TITLE
Use the current .NET version in the target framework.

### DIFF
--- a/FSharpMacCoolApp/dotnet/FSharpMacCoolApp.fsproj
+++ b/FSharpMacCoolApp/dotnet/FSharpMacCoolApp.fsproj
@@ -4,7 +4,7 @@
     <!--
         // We test this because ? F# and notarization (it's not in the App Store [Connect])
     -->
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharpMacCoolApp</RootNamespace>

--- a/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
+++ b/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
@@ -4,7 +4,7 @@
     <!--
         // We test this because ? F# support
     -->
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifiers>ios-arm64;ios-arm</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharpiOSCoolApp</RootNamespace>

--- a/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
+++ b/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
@@ -5,7 +5,7 @@
         // We test this because ? the linker is disabled and all symbols are present in the binary
         // actually because of QTKit deprecation we are forced to use "Link SDK" and an XML file that preserve (almost) everything else
     -->
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <RuntimeIdentifiers>osx-arm64;osx-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>MacCoolApp</RootNamespace>

--- a/MyCatalystApp/MyCatalystApp.csproj
+++ b/MyCatalystApp/MyCatalystApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <OutputType>Exe</OutputType>
     <MtouchLink>SdkOnly</MtouchLink>
 

--- a/MyFatCatalystApp/MyFatCatalystApp.csproj
+++ b/MyFatCatalystApp/MyFatCatalystApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>maccatalyst-arm64;maccatalyst-x64</RuntimeIdentifiers>
     <MtouchLink>SdkOnly</MtouchLink>

--- a/MyNotarizedCatalystApp/MyNotarizedCatalystApp.csproj
+++ b/MyNotarizedCatalystApp/MyNotarizedCatalystApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>maccatalyst-arm64</RuntimeIdentifier>
 

--- a/MyUnlinkedCatalystApp/MyUnlinkedCatalystApp.csproj
+++ b/MyUnlinkedCatalystApp/MyUnlinkedCatalystApp.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <OutputType>Exe</OutputType>
     <MtouchLink>None</MtouchLink>
 

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
@@ -4,7 +4,7 @@
     <!--
         // We test this because ? the linker is disabled and all symbols are present in the binary
     -->
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>ODRsTVOS</RootNamespace>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/ODRsTVOSExt.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/ODRsTVOSExt.csproj
@@ -4,7 +4,7 @@
     <!--
         // We test this because ? the linker is disabled and all symbols are present in the binary
     -->
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <RootNamespace>ODRsTVOSExt</RootNamespace>
     <AssemblyName>ODRsTVOSExt</AssemblyName>

--- a/SceneKitGame/dotnet/SceneKitGame.csproj
+++ b/SceneKitGame/dotnet/SceneKitGame.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>SceneKitGame</RootNamespace>

--- a/UICatalog/dotnet/UICatalog.csproj
+++ b/UICatalog/dotnet/UICatalog.csproj
@@ -4,7 +4,7 @@
     <!--
         // We test this because ? the linker is disabled and all symbols are present in the binary
     -->
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>UICatalog</RootNamespace>

--- a/iOSCoolApp/dotnet/iOSCoolApp.csproj
+++ b/iOSCoolApp/dotnet/iOSCoolApp.csproj
@@ -4,7 +4,7 @@
     <!--
         // We test this because ? interpreter support
     -->
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifiers>ios-arm64;ios-arm</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>iOSCoolApp</RootNamespace>

--- a/iTravel/dotnet/iTravel.csproj
+++ b/iTravel/dotnet/iTravel.csproj
@@ -6,7 +6,7 @@
         // - Build without LLVM (i.e. Mono AOT)
         // - No 32bits slice since it's too big to be generated successfully (since mono-2019-02)
     -->
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier> <!-- test case is 64-bit only -->
     <OutputType>Exe</OutputType>
     <RootNamespace>iTravel</RootNamespace>


### PR DESCRIPTION
We build using a very specific version of .NET + our workloads, so make sure
to use the .NET version we want (the current one), instead of an older .NET
version.