### PR TITLE
Fix failing submission tests for net8.0-xcode15 updates

### DIFF
--- a/FSharpMacCoolApp/FSharpMacCoolApp/Info.plist
+++ b/FSharpMacCoolApp/FSharpMacCoolApp/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.11</string>
+	<string>10.15</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/FSharpMacCoolApp/dotnet/FSharpMacCoolApp.fsproj
+++ b/FSharpMacCoolApp/dotnet/FSharpMacCoolApp.fsproj
@@ -4,7 +4,8 @@
     <!--
         // We test this because ? F# and notarization (it's not in the App Store [Connect])
     -->
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net8.0-macos</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharpMacCoolApp</RootNamespace>

--- a/FSharpMacCoolApp/dotnet/FSharpMacCoolApp.fsproj
+++ b/FSharpMacCoolApp/dotnet/FSharpMacCoolApp.fsproj
@@ -6,6 +6,7 @@
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharpMacCoolApp</RootNamespace>

--- a/FSharpiOSCoolApp/FSharpiOSCoolApp/FSharpiOSCoolApp.fsproj
+++ b/FSharpiOSCoolApp/FSharpiOSCoolApp/FSharpiOSCoolApp.fsproj
@@ -34,7 +34,7 @@
     </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <GenerateTailCalls>true</GenerateTailCalls>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>
@@ -66,7 +66,7 @@
     <OutputPath>bin\iPhone\Debug</OutputPath>
     <DefineConstants>DEBUG;ENABLE_TEST_CLOUD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchFloat32>true</MtouchFloat32>
     <ConsolePause>false</ConsolePause>

--- a/FSharpiOSCoolApp/FSharpiOSCoolApp/Info.plist
+++ b/FSharpiOSCoolApp/FSharpiOSCoolApp/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
+++ b/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
@@ -7,7 +7,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <RuntimeIdentifiers>ios-arm64;ios-arm</RuntimeIdentifiers>
+    <RuntimeIdentifiers>ios-arm64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharpiOSCoolApp</RootNamespace>
     <AssemblyName>FSharpiOSCoolApp</AssemblyName>

--- a/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
+++ b/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
@@ -6,6 +6,7 @@
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifiers>ios-arm64;ios-arm</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharpiOSCoolApp</RootNamespace>

--- a/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
+++ b/FSharpiOSCoolApp/dotnet/FSharpiOSCoolApp.fsproj
@@ -4,12 +4,13 @@
     <!--
         // We test this because ? F# support
     -->
-    <TargetFramework>net6.0-ios</TargetFramework>
-    <RuntimeIdentifiers>ios-arm64;ios-arm</RuntimeIdentifiers>
+    <TargetFramework>net8.0-ios</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <RuntimeIdentifiers>ios-arm64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharpiOSCoolApp</RootNamespace>
     <AssemblyName>FSharpiOSCoolApp</AssemblyName>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>
     <BuildIpa>true</BuildIpa>
     <GenerateTailCalls>true</GenerateTailCalls>

--- a/MacCoolApp/MacCoolApp/Info.plist
+++ b/MacCoolApp/MacCoolApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.10</string>
+	<string>10.15</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/MacCoolApp_DontLink/MacCoolApp/Info.plist
+++ b/MacCoolApp_DontLink/MacCoolApp/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.10</string>
+	<string>10.15</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>olegoid</string>
 	<key>NSMainNibFile</key>

--- a/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
+++ b/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
@@ -5,7 +5,8 @@
         // We test this because ? the linker is disabled and all symbols are present in the binary
         // actually because of QTKit deprecation we are forced to use "Link SDK" and an XML file that preserve (almost) everything else
     -->
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net8.0-macos</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifiers>osx-arm64;osx-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>MacCoolApp</RootNamespace>

--- a/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
+++ b/MacCoolApp_DontLink/dotnet/MacCoolApp.csproj
@@ -7,6 +7,7 @@
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifiers>osx-arm64;osx-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>MacCoolApp</RootNamespace>

--- a/MyCatalystApp/MyCatalystApp.csproj
+++ b/MyCatalystApp/MyCatalystApp.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net8.0-maccatalyst</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <OutputType>Exe</OutputType>
     <MtouchLink>SdkOnly</MtouchLink>
 

--- a/MyCatalystApp/MyCatalystApp.csproj
+++ b/MyCatalystApp/MyCatalystApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputType>Exe</OutputType>
     <MtouchLink>SdkOnly</MtouchLink>
 

--- a/MyFatCatalystApp/MyFatCatalystApp.csproj
+++ b/MyFatCatalystApp/MyFatCatalystApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>maccatalyst-arm64;maccatalyst-x64</RuntimeIdentifiers>
     <MtouchLink>SdkOnly</MtouchLink>

--- a/MyFatCatalystApp/MyFatCatalystApp.csproj
+++ b/MyFatCatalystApp/MyFatCatalystApp.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net8.0-maccatalyst</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>maccatalyst-arm64;maccatalyst-x64</RuntimeIdentifiers>
     <MtouchLink>SdkOnly</MtouchLink>

--- a/MyNotarizedCatalystApp/MyNotarizedCatalystApp.csproj
+++ b/MyNotarizedCatalystApp/MyNotarizedCatalystApp.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-maccatalyst</TargetFramework>
+    <TargetFramework>net8.0-maccatalyst</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>maccatalyst-arm64</RuntimeIdentifier>
 

--- a/MyNotarizedCatalystApp/MyNotarizedCatalystApp.csproj
+++ b/MyNotarizedCatalystApp/MyNotarizedCatalystApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifier>maccatalyst-arm64</RuntimeIdentifier>
 

--- a/MyUnlinkedCatalystApp/MyUnlinkedCatalystApp.csproj
+++ b/MyUnlinkedCatalystApp/MyUnlinkedCatalystApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputType>Exe</OutputType>
     <MtouchLink>None</MtouchLink>
 

--- a/MyUnlinkedCatalystApp/MyUnlinkedCatalystApp.csproj
+++ b/MyUnlinkedCatalystApp/MyUnlinkedCatalystApp.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net8.0-maccatalyst</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <OutputType>Exe</OutputType>
     <MtouchLink>None</MtouchLink>
 

--- a/ODRsTVOS/ODRsTVOS/Info.plist
+++ b/ODRsTVOS/ODRsTVOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>9.2</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>

--- a/ODRsTVOS_Extension/ODRsTVOS/Info.plist
+++ b/ODRsTVOS_Extension/ODRsTVOS/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.xamarin.odr-tvos</string>
 	<key>MinimumOSVersion</key>
-	<string>9.2</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>

--- a/ODRsTVOS_Extension/ODRsTVOSExt/Info.plist
+++ b/ODRsTVOS_Extension/ODRsTVOSExt/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>MinimumOSVersion</key>
-	<string>10.2</string>
+	<string>11.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
@@ -4,12 +4,13 @@
     <!--
         // We test this because ? the linker is disabled and all symbols are present in the binary
     -->
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net8.0-tvos</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>ODRsTVOS</RootNamespace>
     <AssemblyName>ODRsTVOS</AssemblyName>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
 
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOS/ODRsTVOS.csproj
@@ -6,6 +6,7 @@
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>ODRsTVOS</RootNamespace>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/ODRsTVOSExt.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/ODRsTVOSExt.csproj
@@ -6,6 +6,7 @@
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <RootNamespace>ODRsTVOSExt</RootNamespace>
     <AssemblyName>ODRsTVOSExt</AssemblyName>

--- a/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/ODRsTVOSExt.csproj
+++ b/ODRsTVOS_Extension/dotnet/ODRsTVOSExt/ODRsTVOSExt.csproj
@@ -4,12 +4,13 @@
     <!--
         // We test this because ? the linker is disabled and all symbols are present in the binary
     -->
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net8.0-tvos</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <RootNamespace>ODRsTVOSExt</RootNamespace>
     <AssemblyName>ODRsTVOSExt</AssemblyName>
     <IsAppExtension>true</IsAppExtension>
-    <SupportedOSPlatformVersion>10.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
 
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>

--- a/SceneKitGame/SceneKitGame/Info.plist
+++ b/SceneKitGame/SceneKitGame/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.xamarin.scenekit-tvos</string>
 	<key>MinimumOSVersion</key>
-	<string>9.1</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>

--- a/SceneKitGame/dotnet/SceneKitGame.csproj
+++ b/SceneKitGame/dotnet/SceneKitGame.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>SceneKitGame</RootNamespace>

--- a/SceneKitGame/dotnet/SceneKitGame.csproj
+++ b/SceneKitGame/dotnet/SceneKitGame.csproj
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net8.0-tvos</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>SceneKitGame</RootNamespace>
     <AssemblyName>SceneKitGame</AssemblyName>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
 
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>

--- a/UICatalog/UICatalog/Info.plist
+++ b/UICatalog/UICatalog/Info.plist
@@ -22,7 +22,7 @@
 	<key>GCSupportsControllerUserInteraction</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>3</integer>

--- a/UICatalog/dotnet/UICatalog.csproj
+++ b/UICatalog/dotnet/UICatalog.csproj
@@ -6,6 +6,7 @@
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>UICatalog</RootNamespace>

--- a/UICatalog/dotnet/UICatalog.csproj
+++ b/UICatalog/dotnet/UICatalog.csproj
@@ -4,12 +4,13 @@
     <!--
         // We test this because ? the linker is disabled and all symbols are present in the binary
     -->
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net8.0-tvos</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifier>tvos-arm64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <RootNamespace>UICatalog</RootNamespace>
     <AssemblyName>UICatalog</AssemblyName>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
 
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>

--- a/WatchOS/MainApp.WatchApp/Info.plist
+++ b/WatchOS/MainApp.WatchApp/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>5.0</string>
+	<string>9.0</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/WatchOS/MainApp.WatchApp/MainApp.WatchApp.csproj
+++ b/WatchOS/MainApp.WatchApp/MainApp.WatchApp.csproj
@@ -43,7 +43,7 @@
     <MtouchEnableBitcode>true</MtouchEnableBitcode>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <IOSDebugOverWiFi>false</IOSDebugOverWiFi>
     <MtouchVerbosity></MtouchVerbosity>
@@ -81,7 +81,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <IOSDebuggerPort>28208</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <IOSDebugOverWiFi>false</IOSDebugOverWiFi>
     <MtouchVerbosity></MtouchVerbosity>

--- a/WatchOS/MainApp.WatchAppExtension/Info.plist
+++ b/WatchOS/MainApp.WatchAppExtension/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>5.0</string>
+	<string>9.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WatchOS/MainApp.WatchAppExtension/MainApp.WatchAppExtension.csproj
+++ b/WatchOS/MainApp.WatchAppExtension/MainApp.WatchAppExtension.csproj
@@ -43,12 +43,12 @@
     <MtouchEnableBitcode>true</MtouchEnableBitcode>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <IOSDebugOverWiFi>false</IOSDebugOverWiFi>
     <MtouchVerbosity></MtouchVerbosity>
     <CodesignProvision>WatchKit Catalog Watch App Extension</CodesignProvision>
-    <MtouchExtraArgs>--abi=armv7k+llvm,arm64_32+llvm</MtouchExtraArgs>
+    <MtouchExtraArgs>--abi=arm64_32+llvm</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>pdbonly</DebugType>
@@ -82,7 +82,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <IOSDebuggerPort>42332</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <IOSDebugOverWiFi>false</IOSDebugOverWiFi>
     <MtouchVerbosity></MtouchVerbosity>

--- a/WatchOSIntents/intentsphone/Info.plist
+++ b/WatchOSIntents/intentsphone/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>MinimumOSVersion</key>
-	<string>10.3</string>
+	<string>11.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WatchOSIntents/intentsphone/intentsphone.csproj
+++ b/WatchOSIntents/intentsphone/intentsphone.csproj
@@ -40,7 +40,7 @@
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <CodesignProvision>Intents Sample - Distribution Profile</CodesignProvision>
   </PropertyGroup>
@@ -76,7 +76,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <IOSDebuggerPort>10001</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <CodesignProvision></CodesignProvision>
   </PropertyGroup>

--- a/WatchOSIntents/intentsphoneUI/Info.plist
+++ b/WatchOSIntents/intentsphoneUI/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>10.3</string>
+	<string>11.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WatchOSIntents/intentsphoneUI/intentsphoneUI.csproj
+++ b/WatchOSIntents/intentsphoneUI/intentsphoneUI.csproj
@@ -40,7 +40,7 @@
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <CodesignProvision>Intents Sample - Distribution Profile</CodesignProvision>
   </PropertyGroup>
@@ -76,7 +76,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <IOSDebuggerPort>10001</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>

--- a/WatchOSIntents/intentswatch/Info.plist
+++ b/WatchOSIntents/intentswatch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>3.2</string>
+	<string>10.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WatchOSIntents/intentswatch/intentswatch.csproj
+++ b/WatchOSIntents/intentswatch/intentswatch.csproj
@@ -42,9 +42,9 @@
     <MtouchEnableBitcode>true</MtouchEnableBitcode>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-    <MtouchExtraArgs>--abi=armv7k+llvm,arm64_32+llvm</MtouchExtraArgs>
+    <MtouchExtraArgs>--abi=arm64_32+llvm</MtouchExtraArgs>
     <CodesignProvision>Intents Sample - Distribution Profile</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
@@ -80,7 +80,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <IOSDebuggerPort>10001</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>

--- a/WatchOSIntents/intentsxamsample.watchkitapp/Info.plist
+++ b/WatchOSIntents/intentsxamsample.watchkitapp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>3.2</string>
+	<string>10.0</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/WatchOSIntents/intentsxamsample.watchkitapp/intentsxamsample.watchkitapp.csproj
+++ b/WatchOSIntents/intentsxamsample.watchkitapp/intentsxamsample.watchkitapp.csproj
@@ -42,7 +42,7 @@
     <MtouchEnableBitcode>true</MtouchEnableBitcode>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <CodesignProvision>Intents Sample - Distribution Profile</CodesignProvision>
   </PropertyGroup>
@@ -78,7 +78,7 @@
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>

--- a/WatchOSIntents/intentsxamsample.watchkitappExtension/Info.plist
+++ b/WatchOSIntents/intentsxamsample.watchkitappExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>MinimumOSVersion</key>
-	<string>3.2</string>
+	<string>10.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WatchOSIntents/intentsxamsample.watchkitappExtension/intentsxamsample.watchkitappExtension.csproj
+++ b/WatchOSIntents/intentsxamsample.watchkitappExtension/intentsxamsample.watchkitappExtension.csproj
@@ -42,10 +42,10 @@
     <MtouchEnableBitcode>true</MtouchEnableBitcode>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <CodesignProvision>Intents Sample - Distribution Profile</CodesignProvision>
-    <MtouchExtraArgs>--abi=armv7k+llvm,arm64_32+llvm</MtouchExtraArgs>
+    <MtouchExtraArgs>--abi=arm64_32+llvm</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>pdbonly</DebugType>
@@ -80,7 +80,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <IOSDebuggerPort>10001</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7k</MtouchArch>
+    <MtouchArch>ARM64_32</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>

--- a/WatchOSIntents/intentsxamsample/Info.plist
+++ b/WatchOSIntents/intentsxamsample/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>10.3</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/WatchOSIntents/intentsxamsample/intentsxamsample.csproj
+++ b/WatchOSIntents/intentsxamsample/intentsxamsample.csproj
@@ -40,7 +40,7 @@
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <PlatformTarget>x86</PlatformTarget>
     <BuildIpa>true</BuildIpa>
@@ -77,7 +77,7 @@
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <PlatformTarget>x86</PlatformTarget>
     <CodesignProvision></CodesignProvision>

--- a/iOSCoolApp/dotnet/iOSCoolApp.csproj
+++ b/iOSCoolApp/dotnet/iOSCoolApp.csproj
@@ -4,12 +4,13 @@
     <!--
         // We test this because ? interpreter support
     -->
-    <TargetFramework>net6.0-ios</TargetFramework>
-    <RuntimeIdentifiers>ios-arm64;ios-arm</RuntimeIdentifiers>
+    <TargetFramework>net8.0-ios</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <RuntimeIdentifiers>ios-arm64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>iOSCoolApp</RootNamespace>
     <AssemblyName>iOSCoolApp</AssemblyName>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>
     <CodesignProvision>iOS Publish Workflow II - Distribution Profile (.N</CodesignProvision>
     <BuildIpa>true</BuildIpa>

--- a/iOSCoolApp/dotnet/iOSCoolApp.csproj
+++ b/iOSCoolApp/dotnet/iOSCoolApp.csproj
@@ -6,6 +6,7 @@
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifiers>ios-arm64;ios-arm</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>iOSCoolApp</RootNamespace>

--- a/iOSCoolApp/dotnet/iOSCoolApp.csproj
+++ b/iOSCoolApp/dotnet/iOSCoolApp.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <RuntimeIdentifiers>ios-arm64;ios-arm</RuntimeIdentifiers>
+    <RuntimeIdentifiers>ios-arm64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>iOSCoolApp</RootNamespace>
     <AssemblyName>iOSCoolApp</AssemblyName>

--- a/iOSCoolApp/iOSCoolApp/Info.plist
+++ b/iOSCoolApp/iOSCoolApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/iOSCoolApp/iOSCoolApp/iOSCoolApp.csproj
+++ b/iOSCoolApp/iOSCoolApp/iOSCoolApp.csproj
@@ -32,7 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>
     <BuildIpa>true</BuildIpa>
@@ -63,7 +63,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchProfiling>true</MtouchProfiling>
     <CodesignKey>iPhone Developer</CodesignKey>

--- a/iTravel/dotnet/iTravel.csproj
+++ b/iTravel/dotnet/iTravel.csproj
@@ -8,6 +8,7 @@
     -->
     <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier> <!-- test case is 64-bit only -->
     <OutputType>Exe</OutputType>
     <RootNamespace>iTravel</RootNamespace>

--- a/iTravel/dotnet/iTravel.csproj
+++ b/iTravel/dotnet/iTravel.csproj
@@ -6,12 +6,13 @@
         // - Build without LLVM (i.e. Mono AOT)
         // - No 32bits slice since it's too big to be generated successfully (since mono-2019-02)
     -->
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier> <!-- test case is 64-bit only -->
     <OutputType>Exe</OutputType>
     <RootNamespace>iTravel</RootNamespace>
     <AssemblyName>iTravel</AssemblyName>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
     <CodesignKey>Apple Distribution: Luis Aguilera (DPXCPAGVTZ)</CodesignKey>
     <OnDemandResourcesPrefetchOrder>paris</OnDemandResourcesPrefetchOrder>
     <OnDemandResourcesInitialInstallTags>rotterdam</OnDemandResourcesInitialInstallTags>

--- a/iTravel/iTravel/Info.plist
+++ b/iTravel/iTravel/Info.plist
@@ -11,7 +11,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/iTravel/iTravel/iTravel.csproj
+++ b/iTravel/iTravel/iTravel.csproj
@@ -74,7 +74,7 @@
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>None</MtouchLink>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <PlatformTarget>x86</PlatformTarget>
     <OnDemandResourcesInitialInstallTags>Istanbul</OnDemandResourcesInitialInstallTags>
     <OnDemandResourcesPrefetchOrder>Paris</OnDemandResourcesPrefetchOrder>


### PR DESCRIPTION
All tests are passing with the exception of the watchOS intents sample. This is because of a mismatch in min os version support due to the recent change of armv7k arch no longer being supported and the defined version in Xamarin.framework.

Contributes to https://github.com/xamarin/maccore/issues/2696

armv7k issue: https://github.com/xamarin/xamarin-macios/issues/18902 
xamarin.framework versions updated: https://github.com/xamarin/xamarin-macios/pull/18912

Merge after https://github.com/xamarin/SubmissionSamples/pull/53 , https://github.com/xamarin/SubmissionSamples/pull/54