### PR TITLE
[.NET] ignore nuget.config, global.json for default .net apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ packages/
 */*/obj/*
 */*/*/bin/*
 */*/*/obj/*
+
+*/Nuget.config
+*/global.json
+*.sln


### PR DESCRIPTION
This is a follow up to the recent native AOT app submission entries. The submission test runner in maccore adds the nuget config/global json to each project so they can be ignored and make the local working state a bit cleaner in between test runs. 

The sln file is auto-added when the projects are opened in c# dev kit.